### PR TITLE
DQR-3084 added check for 550 so it doesn't timeout when waiting for no data

### DIFF
--- a/joeftp.go
+++ b/joeftp.go
@@ -309,6 +309,13 @@ func (ftp *JoeFtp) passive(command string, dataIn []byte) (int, string, []byte, 
 	}
 
 	data := []byte{}
+
+	if code == 550 {
+		//550 is not expecting anymore data. let's end it now  and send it back. 
+		//if the cmd was successful & data was coming, code = 125 here
+		return code, msg, data, err
+	}
+
 	if dataIn == nil {
 		b := make([]byte, 1)
 		readStream := true


### PR DESCRIPTION
for some strange reason, z/OS level 2 returns a LIST with a 550. This causes a break in here, so we just check to make sure it's not a 550 before looking for more data.